### PR TITLE
feat: add two charts on Statistic page

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "webpack-dev-server": "^4.9.3"
   },
   "dependencies": {
+    "chart.js": "^3.9.1",
+    "chartjs-adapter-date-fns": "^2.0.0",
+    "date-fns": "^2.29.2",
     "dotenv": "^16.0.1"
   }
 }

--- a/src/Pages/Statistic/Statistic.ts
+++ b/src/Pages/Statistic/Statistic.ts
@@ -2,6 +2,7 @@
 import { Component } from "../../Abstract/component";
 import { TServices } from "../../Interfaces/Types";
 import { GamesStatistic } from "./Statistics-block/Games-statistic";
+import { Graph } from "./Statistics-block/Graph";
 import { WordsStatistic } from "./Statistics-block/Word-statistic";
 
 export class Statistic extends Component {
@@ -32,6 +33,12 @@ export class Statistic extends Component {
  
   wordsStatistic: WordsStatistic;
 
+  charts: Component;
+
+  graphNewWords: Graph;
+
+  graphLearnedWords: Graph;
+
   constructor(parent: HTMLElement, private readonly services: TServices) {
    
     super(parent, 'div', ['statistic-wrapper']);
@@ -54,6 +61,16 @@ export class Statistic extends Component {
 
     this.wordsStatistic = new WordsStatistic(this.statistic.root);
 
+    this.charts = new Component(this.root, 'div', ['charts-block']);
+
+    this.graphNewWords =  new Graph(this.charts.root, services);
+    this.graphNewWords.title.root.innerText = 'Динамика появления новых слов';
+    this.graphNewWords.myChart.data.datasets[0].label = 'новых словов';
+    
+    this.graphLearnedWords = new Graph(this.charts.root, services);
+    this.graphLearnedWords.title.root.innerText = 'Динамика изучения слов';
+    this.graphLearnedWords.myChart.data.datasets[0].label = 'изученных слов';
+    
     this.exit.root.onclick = () => this.services.lang.userLogout();
 
     this.buttonSaveName.root.onclick = () => {
@@ -67,5 +84,37 @@ export class Statistic extends Component {
 
     this.services.lang.updateStatisticPage();
 
+    this.getUpdateCharts();
+
+    window.addEventListener('hashchange', () => {
+      if (document.location.hash === '#statistic') {
+        this.getUpdateCharts();
+      }
+    });
+
+  }
+
+  getUpdateCharts(): void {
+    this.services.lang.getStatisticDataChart()
+      .then((response) => {
+        if (response) {
+          const labels = [] as Date[];
+          const dataNewWords = [] as number[];
+          const dataLearnedWords = [] as number[];
+          response.optional.data.dataPerDay.forEach(({date, newWords, learnedWords}) => {
+            labels.push(new Date(`${date} 00:00`));
+            dataNewWords.push(newWords);
+            dataLearnedWords.push(learnedWords);
+          });
+
+          this.graphNewWords.myChart.data.labels = labels;
+          this.graphNewWords.myChart.data.datasets[0].data = dataNewWords;
+          this.graphNewWords.myChart.update();
+          
+          this.graphLearnedWords.myChart.data.labels = labels;
+          this.graphLearnedWords.myChart.data.datasets[0].data = dataLearnedWords;
+          this.graphLearnedWords.myChart.update();
+        }
+      });
   }
 }

--- a/src/Pages/Statistic/Statistics-block/Graph.ts
+++ b/src/Pages/Statistic/Statistics-block/Graph.ts
@@ -1,0 +1,65 @@
+import { Component } from '../../../Abstract/component';
+import { TServices } from '../../../Interfaces/Types';
+import Chart from 'chart.js/auto';
+import 'chartjs-adapter-date-fns';
+import {ru} from 'date-fns/locale';
+import './graph.scss';
+
+export class Graph extends Component {
+  
+  title: Component;
+  
+  graph: HTMLCanvasElement;
+
+  myChart: Chart;
+
+  constructor(parent: HTMLElement, private readonly services: TServices) {
+    super(parent, 'div', ['chart-wrapper']);
+    this.title = new Component(this.root, 'h3', []);
+
+    this.graph = new Component(this.root, 'canvas', ['chart']).root as HTMLCanvasElement;
+
+    this.myChart = new Chart(this.graph, {
+      type: 'line',
+      data: {
+        labels: [new Date()],
+        datasets: [{
+          label: 'метка',
+          data: [0],
+          backgroundColor: 'rgba(255, 0, 0, 1)',
+          borderColor: 'rgba(0, 206, 86, 1)',
+          borderWidth: 1,
+        }]
+      },
+      options: {
+        plugins: {
+          legend: {
+            display: false
+          }
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              unit: 'day',
+              displayFormats: {
+                day: 'dd.MM.yy',
+              }
+            },
+            ticks: {
+              source: 'auto'
+            },
+            adapters: {
+              date: {
+                locale: ru
+              }
+            }
+          },
+          y: {
+            beginAtZero: true
+          }
+        }
+      }
+    });
+  }
+}

--- a/src/Pages/Statistic/Statistics-block/graph.scss
+++ b/src/Pages/Statistic/Statistics-block/graph.scss
@@ -1,0 +1,11 @@
+.chart {
+  width: 400px;
+  height: 400px;
+}
+
+.chart-wrapper {
+  h3 {
+    text-align: center;
+    font-size: 20px;
+  }
+}

--- a/src/Services/LangService.ts
+++ b/src/Services/LangService.ts
@@ -1,6 +1,5 @@
 import { Observer } from "../Abstract/Observer";
-import { IResponse } from "../Interfaces/Interfaces";
-import { TAuthResponse, TWord } from "../Interfaces/Types";
+import { TUserStatistic } from "../Interfaces/Types";
 import  APIService  from "./APIService";
 
 
@@ -42,5 +41,13 @@ export class LangService extends Observer {
   updateStatisticPage(): void {
     const {name} = APIService.getAuthUser();
     this.dispatch('updateName', name);
+  }
+
+  async getStatisticDataChart(): Promise<TUserStatistic | null> {
+    const response = await APIService.getUserStatistics();
+    if (response && response.data.optional.data.dataPerDay.length > 0) {
+      return response.data;
+    };
+    return null;
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export function getRandomNumber(max: number) {
 }
 
 export function createDate(): string {
-  return new Date().toLocaleString().split(',')[0];
+  return new Date().toLocaleDateString().split('.').reverse().join('-');
 }
 
 // генерация случайного массива n элементов


### PR DESCRIPTION
1. Подключена библиотека Chart.js, позволяющая создавать диаграммы. Не забудьте про "npm i"
2. На странице Статистика добавлены диаграммы:
- график, отображающий количество новых слов за каждый день изучения;
- график, отображающий увеличение общего количества изученных слов за весь период обучения по дням.
3. Изменен формат хранения даты в статистике.

![image](https://user-images.githubusercontent.com/57761811/187897377-5c4727ea-83fd-4c99-8e02-ca2e0b3a4c7d.png)
