### PR TITLE
fix: bug with statistic render

### DIFF
--- a/src/Pages/Statistic/Statistic.ts
+++ b/src/Pages/Statistic/Statistic.ts
@@ -116,4 +116,11 @@ export class Statistic extends Component {
       }
     });
   }
+
+  render(): void {
+    super.render();
+    this.gamesAudiocall.getStatistic();
+    this.gamesSprint.getStatistic();
+    this.wordsStatistic.getStat();
+  }
 }

--- a/src/Pages/Statistic/Statistics-block/Games-statistic.ts
+++ b/src/Pages/Statistic/Statistics-block/Games-statistic.ts
@@ -34,17 +34,15 @@ export class GamesStatistic extends Component {
     const bestGame = new Component(bestGameBlock.root, 'div', ['best-game']);
     const bestGameTitle = new Component(bestGame.root, 'p', [], 'Лучшая игра');
     this.bestGameCount = new Component(bestGame.root, 'p', [], '0');
-
-    this.getStatistic();
   }
 
-  private async getStatistic() {
+  async getStatistic() {
     const stat = await APIService.getUserSetting();
     if (stat) {
       const percent = Math.floor(
         (stat.data.optional[this.game].correctAnswers / stat.data.optional[this.game].answersCount) * 100,
       );
-      this.numberPercent!.root.textContent = validateNum(stat.data.optional[this.game].answersCount);
+      this.numberPercent!.root.textContent = validateNum(stat.data.optional[this.game].newWords);
       this.rightAnswersPercent!.root.textContent = `${validateNum(percent)} %`;
       this.bestGameCount!.root.textContent = validateNum(stat.data.optional[this.game].streak);
     } else {
@@ -53,5 +51,4 @@ export class GamesStatistic extends Component {
       this.bestGameCount!.root.textContent = '0';
     }
   }
-
 }

--- a/src/Pages/Statistic/Statistics-block/Word-statistic.ts
+++ b/src/Pages/Statistic/Statistics-block/Word-statistic.ts
@@ -61,19 +61,17 @@ export class WordsStatistic extends Component {
     this.percetnRigrhtWords = new Component(this.percentWords.root, 'div', ['percent-right-words']);
     this.rightWordsTitle = new Component(this.percetnRigrhtWords.root, 'p', [], 'Процент правильных ответов за день');
     this.rightWordsPercent = new Component(this.percetnRigrhtWords.root, 'p', [], '%');
-
-    this.getStat();
   }
 
-  private async getStat() {
+  async getStat() {
     const stat = await APIService.getUserStatistics();
     const set = await APIService.getUserSetting();
     let correct = 0;
     let answCount = 0;
     const length = stat ? stat?.data.optional.data.dataPerDay.length : 0;
     if (stat && length > 0) {
-      this.numberNew.root.textContent = stat?.data.optional.data.dataPerDay[0].newWords.toString();
-      this.numberLearned.root.textContent = stat?.data.optional.data.dataPerDay[0].learnedWords.toString();
+      this.numberNew.root.textContent = stat?.data.optional.data.dataPerDay[length-1].newWords.toString();
+      this.numberLearned.root.textContent = stat?.data.optional.data.dataPerDay[length-1].learnedWords.toString();
       this.totalNumberLearned .root.textContent = stat?.data.learnedWords.toString();
     }
     if (set) {


### PR DESCRIPTION
Переопределил метод рендер, чтобы статистика обновлялась при переходе по страницам (раньше обновлялась только при перезагрузке страницы)  
Пофиксил баг, что выводились все слова, а не новые.