### PR TITLE
refactor: change popup statistic when game started from dictionary

### DIFF
--- a/src/Pages/Sprint/Sprint.ts
+++ b/src/Pages/Sprint/Sprint.ts
@@ -147,6 +147,7 @@ export class Sprint extends Component {
     this.service.sprint.addListener(ESprintEvents.changeCombo, this.setCombo.bind(this));
     this.service.sprint.addListener(ESprintEvents.changeReward, this.setReward.bind(this));
     this.service.sprint.addListener(ESprintEvents.renderStatistic, this.renderStatistic.bind(this));
+    this.service.sprint.addListener(ESprintEvents.renderStatisticDictionary, this.renderStatisticDictionary.bind(this));
 
     this.game.remove();
     window.addEventListener('keydown', this.keyHandler.bind(this));
@@ -247,16 +248,29 @@ export class Sprint extends Component {
   }
 
   private renderStatistic(data: TParams) {
-    this.game.remove();
-    this.dificulty.remove();
-    this.statistic?.remove();
-
+    this.removeGame();
     this.statistic = new StatisticPopup(
       this.root,
       data as TGameAnswer[],
       this.service.sprint.refreshGame.bind(this.service.sprint),
       this.render.bind(this),
     );
+  }
+
+  private renderStatisticDictionary(data: TParams) {
+    this.removeGame();
+    this.statistic = new StatisticPopup(
+      this.root,
+      data as TGameAnswer[],
+      this.service.sprint.refreshGame.bind(this.service.sprint),
+      () => (window.location.hash = '#textbook'),
+    );
+  }
+
+  private removeGame() {
+    this.game.remove();
+    this.dificulty.remove();
+    this.statistic?.remove();
   }
 
   render(): void {

--- a/src/Services/SprintService.ts
+++ b/src/Services/SprintService.ts
@@ -20,6 +20,7 @@ export enum ESprintEvents {
   changeCombo = 'changeCombo',
   changeReward = 'changeReward',
   renderStatistic = 'statistic',
+  renderStatisticDictionary = 'renderStatisticDictionary'
 }
 
 export default class SprintService extends Observer {
@@ -95,7 +96,6 @@ export default class SprintService extends Observer {
     this.isFromDict = true;
     this.difficulty = group as TDifficulty;
     this.pageFromDictionary = page;
-    this.isFromDict = true;
     this.currentWords = (await getWordsFromDict(group, page)) as TAggregatedWord[];
     this.startGame();
   }
@@ -133,7 +133,12 @@ export default class SprintService extends Observer {
 
   async stopGame() {
     this.isGame = false;
-    this.dispatch(ESprintEvents.renderStatistic, this.answers);
+    if(this.isFromDict) {
+      this.dispatch(ESprintEvents.renderStatisticDictionary, this.answers);
+    } else {
+      this.dispatch(ESprintEvents.renderStatistic, this.answers);
+    }
+
     const user = APIService.getAuthUser();
     if (user && APIService.isAuthorizedUser()) {
       WriteStatisticService.writeResults(this.answers, EGames.sprint);


### PR DESCRIPTION
Если игра спринт запущена из словаря, то кнопка "назад" в статистике переносит пользователя в словарь, а не в игру.